### PR TITLE
Attempt to individually assign NumberFormat and PluralRules if the In…

### DIFF
--- a/polyfill-lib/intl/intl.js
+++ b/polyfill-lib/intl/intl.js
@@ -5818,7 +5818,17 @@
 			window.Intl = Intl$1;
 			Intl$1.__applyLocaleSensitivePrototypes();
 		} catch (e) {
-			// can be read only property
+			// Can be read only property. Attempt to assign properties individually
+			try {
+				if (typeof Intl !== "undefined") {
+					if (typeof Intl.NumberFormat === "undefined") {
+						window.Intl.NumberFormat = Intl$1.NumberFormat;
+					}
+					if (typeof Intl.PluralRules === "undefined") {
+						window.Intl.PluralRules = Intl$1.PluralRules;
+					}
+				}
+			} catch (e) {}
 		}
 	}
 


### PR DESCRIPTION
…tl object is read-only

The issue can be reproduced in Android 4.4 on Chrome version 30.